### PR TITLE
use atom.clipboard instead of copy

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -41,7 +41,7 @@ function activate(context) {
 
   const copyToClipboardCommand = commands.registerCommand('cybai.parseYaml.copyToClipboard', function () {
     const parsedResult = getParsedFullKey();
-    copy(parsedResult);
+    atom.clipboard.write(parsedResult);
 
     window.showInformationMessage(`${parsedResult} has been copied to clipboard.`);
   });


### PR DESCRIPTION
See info on clipboard here: https://atom.io/docs/api/v1.29.0/Clipboard