### PR TITLE
Use native vscode command to copy text

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "yaml-key-viewer",
     "displayName": "YAML key viewer",
     "description": "YAML key viewer for Visual Studio Code",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "publisher": "cybai",
     "author": {
         "email": "cyb.ai.815@gmail.com",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,5 @@
         "typescript": "^3.6.4",
         "vscode-test": "^1.2.2"
     },
-    "dependencies": {
-        "copy-paste": "^1.3.0"
-    }
+    "dependencies": {}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import { parseYaml } from './yaml-parser';
-import { copy } from 'copy-paste';
 
 function getParsedFullKey() {
     const editor = vscode.window.activeTextEditor;
@@ -36,7 +35,8 @@ function activate(context: vscode.ExtensionContext) {
         'cybai.parseYaml.copyToClipboard',
         function() {
             const parsedResult = getParsedFullKey();
-            copy(parsedResult);
+
+            vscode.env.clipboard.writeText(parsedResult);
 
             vscode.window.showInformationMessage(
                 `${parsedResult} has been copied to clipboard.`

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,15 +181,6 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-copy-paste@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/copy-paste/-/copy-paste-1.3.0.tgz#a7e6c4a1c28fdedf2b081e72b97df2ef95f471ed"
-  integrity sha1-p+bEocKP3t8rCB5yuX3y75X0ce0=
-  dependencies:
-    iconv-lite "^0.4.8"
-  optionalDependencies:
-    sync-exec "~0.6.x"
-
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -569,7 +560,7 @@ https-proxy-agent@^2.2.4:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
-iconv-lite@^0.4.24, iconv-lite@^0.4.8:
+iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -1130,11 +1121,6 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
-
-sync-exec@~0.6.x:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/sync-exec/-/sync-exec-0.6.2.tgz#717d22cc53f0ce1def5594362f3a89a2ebb91105"
-  integrity sha1-cX0izFPwzh3vVZQ2LzqJouu5EQU=
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
The `copy-paste` package is not actively maintained and the reason for
using it at that time was about no native support for copy from vscode
itself. So, as there's the support for copy from vscode, this extension
can just use it.
