### PR TITLE
The first line of a yaml file is not necessarily ---

### DIFF
--- a/src/yaml-parser.ts
+++ b/src/yaml-parser.ts
@@ -33,8 +33,9 @@ function parseYaml({
 
     const lines = document.getText(range).split('\n');
 
-    // Remove the first line of `---`
-    lines.shift();
+    if (lines[0] == '---') {
+        lines.shift();
+    }
 
     const expectedIndentationLine = isKey(selectedLine.text)
         ? selectedLine.text


### PR DESCRIPTION
Although the spec suggests that yaml files should begin with `---` this is not always the case e.g. helm chart and values files, kubernetes manifests etc.

Skip the first line only if it's `---`.