### PR TITLE
feat: support `ansible` document.languageId

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,9 @@ function getParsedFullKey(editor: vscode.TextEditor): E.Either<Error, string> {
     const document = editor.document;
 
     switch (document.languageId) {
-        case 'yaml': {
+        case 'yaml': 
+        case 'ansible':
+        {
             const parsedE = parseYaml(editor);
 
             return E.map(parsed =>


### PR DESCRIPTION
Value is based on [[vscode-ansible's code](https://github.com/ansible/vscode-ansible/blob/aea832bee8b178f73dfb7f2e7291f1928eb9fe60/src/features/ansibleMetaData.ts#L55)].

Please run the test before merging I didn't install locally